### PR TITLE
refactor: unify ETF input across modules

### DIFF
--- a/frontend/src/components/RegressionForm.jsx
+++ b/frontend/src/components/RegressionForm.jsx
@@ -1,10 +1,6 @@
 import React from "react";
-import {
-  Grid,
-  TextField,
-  MenuItem,
-  Button
-} from "@mui/material";
+import { Grid, TextField, MenuItem, Button } from "@mui/material";
+import EtfListInput from "./EtfListInput";
 
 const modelOptions = ["CAPM", "FF3", "FF4", "FF5"];
 
@@ -14,81 +10,73 @@ export default function RegressionForm({ form, setForm, onSubmit, loading }) {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
-
-
   return (
-    <Grid container spacing={2}>
-      <Grid item xs={6} sm={4} md={3}>
-        <TextField
-          name="ticker"
-          label="Ticker"
-          value={form.ticker}
-          onChange={handleChange}
-          fullWidth
-        />
-      </Grid>
-      <Grid item xs={6} sm={4} md={3}>
-        <TextField
-          name="model"
-          label="Model"
-          value={form.model}
-          onChange={handleChange}
-          select
-          fullWidth
-        >
-          {modelOptions.map((m) => (
-            <MenuItem key={m} value={m}>
-              {m}
-            </MenuItem>
-          ))}
-        </TextField>
-      </Grid>
+    <>
+      <EtfListInput
+        etflist={form.etflist}
+        setEtflist={(newList) => setForm({ ...form, etflist: newList })}
+      />
+      <Grid container spacing={2}>
+        <Grid item xs={6} sm={4} md={3}>
+          <TextField
+            name="model"
+            label="Model"
+            value={form.model}
+            onChange={handleChange}
+            select
+            fullWidth
+          >
+            {modelOptions.map((m) => (
+              <MenuItem key={m} value={m}>
+                {m}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
 
-      <Grid item xs={6} sm={4} md={3}>
-
-        <TextField
+        <Grid item xs={6} sm={4} md={3}>
+          <TextField
             label="Start Date"
             type="date"
             value={form.start_date}
             onChange={(e) => setForm({ ...form, start_date: e.target.value })}
             InputLabelProps={{ shrink: true }}
             fullWidth
-            />
-
-      </Grid>
-      <Grid item xs={6} sm={4} md={3}>
-        <TextField
+          />
+        </Grid>
+        <Grid item xs={6} sm={4} md={3}>
+          <TextField
             label="End Date"
             type="date"
             value={form.end_date}
             onChange={(e) => setForm({ ...form, end_date: e.target.value })}
             InputLabelProps={{ shrink: true }}
             fullWidth
-            />
+          />
+        </Grid>
+        <Grid item xs={4}>
+          <TextField
+            label="Rolling Period (months)"
+            type="number"
+            value={form.rolling_period || 36}
+            onChange={(e) =>
+              setForm({ ...form, rolling_period: parseInt(e.target.value) })
+            }
+            fullWidth
+          />
+        </Grid>
 
+        <Grid item xs={12} sm={4} md={3}>
+          <Button
+            variant="contained"
+            onClick={onSubmit}
+            fullWidth
+            disabled={loading}
+          >
+            Run Regression
+          </Button>
+        </Grid>
       </Grid>
-      <Grid item xs={4}>
-        <TextField
-          label="Rolling Period (months)"
-          type="number"
-          value={form.rolling_period || 36}
-          onChange={(e) =>
-            setForm({ ...form, rolling_period: parseInt(e.target.value) })
-          }
-          fullWidth
-        />
-      </Grid>
-
-      <Grid item xs={12} sm={4} md={3}>
-        <Button
-          variant="contained"
-          onClick={onSubmit}
-          fullWidth
-          disabled={loading}
-        >
-          Run Regression
-        </Button>
-      </Grid>
-    </Grid>
+    </>
   );
 }

--- a/frontend/src/components/RegressionPage.jsx
+++ b/frontend/src/components/RegressionPage.jsx
@@ -6,11 +6,11 @@ import RegressionResult from "./RegressionResult";
 
 export default function RegressionPage() {
   const [form, setForm] = useState({
-    ticker: "AAPL",
+    etflist: ["AAPL"],
     model: "FF3",
     start_date: "2020-01-01",
     end_date: "2023-12-31",
-    rolling_period: 36
+    rolling_period: 36,
   });
 
   const [result, setResult] = useState(null);
@@ -20,7 +20,12 @@ export default function RegressionPage() {
     setLoading(true);
     setResult(null);
     try {
-      const res = await axios.post(`${process.env.REACT_APP_API_BASE_URL}/regression`, form);
+      const { etflist, ...rest } = form;
+      const payload = { ...rest, ticker: etflist[0] };
+      const res = await axios.post(
+        `${process.env.REACT_APP_API_BASE_URL}/regression`,
+        payload
+      );
       setResult(res.data);
     } catch (err) {
       console.error("Regression error:", err);


### PR DESCRIPTION
## Summary
- reuse shared EtfListInput component in regression form
- send first selected ETF ticker to regression API for consistency with other modules

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab906b2c5083309b341c096889840a