### PR TITLE
Improve ETF input sizing and suggestion list

### DIFF
--- a/frontend/src/components/EtfListInput.jsx
+++ b/frontend/src/components/EtfListInput.jsx
@@ -78,11 +78,18 @@ export default function EtfListInput({ etflist, setEtflist }) {
       </Typography>
       <Grid container spacing={12}>
         {etflist.map((etf, idx) => (
-          <Grid item xs={12} sm={6} md={4} key={idx}>
+          <Grid item xs={12} md={6} key={idx}>
             <Box position="relative">
               <Autocomplete
                 freeSolo
                 options={options}
+                filterOptions={(opts, { inputValue }) =>
+                  opts
+                    .filter((opt) =>
+                      opt.toLowerCase().includes(inputValue.toLowerCase())
+                    )
+                    .slice(0, 10)
+                }
                 inputValue={etf}
                 onInputChange={(e, value) => handleEtfChange(idx, value)}
                 onChange={(e, value) => {
@@ -113,7 +120,7 @@ export default function EtfListInput({ etflist, setEtflist }) {
             </Box>
           </Grid>
         ))}
-        <Grid item xs={12} sm={6} md={4}>
+        <Grid item xs={12} md={6}>
           <Button
             variant="outlined"
             startIcon={<AddIcon />}


### PR DESCRIPTION
## Summary
- widen ETF ticker fields for better usability
- limit auto-complete dropdown to 10 items to speed up selection

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68abd5b10c7883308b7ec0d4c3e93dc5